### PR TITLE
Docs typo: change `nontains` to `contains`

### DIFF
--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -265,7 +265,7 @@ This overrides the database connection strings in **default.json** and prevents 
 npm, or yarn if that's installed.
 The dependencies are enumerated in `package.json`.
 
-- **public/** nontains the resources to be served.
+- **public/** contains the resources to be served.
 A sample favicon and HTML file are included.
 
 - **src/** contains the Feathers server.

--- a/docs/get-started/README.md
+++ b/docs/get-started/README.md
@@ -3019,7 +3019,7 @@ cli-plus will not overwrite any module names you add to *freeze*. For example
 You can list all the custom code in your app using
 
 ```
-feathers-plus codelist
+feathers-plus generate codelist
 ```
 
 <collapse-image hidden title="Prompts 'generate codelist'" url="/assets/get-started/generate-codelist.png" />


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.
Fixes docs typo `nontains` should be `contains` at https://generator.feathers-plus.com/get-started/#generate-options
- [x] Are there any open issues that are related to this?
No
- [x] Is this PR dependent on PRs in other repos?
No